### PR TITLE
Fixed to bootstrap5  examples

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,10 @@
 *.st linguist-language=Smalltalk
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+*.st text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/src/Bootstrap5-Core/SBSCDNDeploymentLibrary.class.st
+++ b/src/Bootstrap5-Core/SBSCDNDeploymentLibrary.class.st
@@ -22,7 +22,7 @@ SBSCDNDeploymentLibrary >> cdnLocationIntegrity [
 { #category : #updating }
 SBSCDNDeploymentLibrary >> updateRoot: anHTMLRoot [
 
-	| style script |
+	| style "script" |								"<sm> variable script not required "
 	super updateRoot: anHTMLRoot.
 	style := anHTMLRoot stylesheet.
 	style url: self cdnLocation.
@@ -30,11 +30,12 @@ SBSCDNDeploymentLibrary >> updateRoot: anHTMLRoot [
 		at: 'integrity' append: self cdnLocationIntegrity;
 		at: 'crossorigin' append: 'anonymous'.
 	
+	"<sm> commented / disabled as this is not reqd in header instead before closing /body tag"	
 		
-	script := anHTMLRoot javascript.
+	"script := anHTMLRoot javascript.
 	script url: 'https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js'.
 	script attributes 
 		at: 'integrity' append: 'sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4';
-		at: 'crossorigin' append: 'anonymous'.	
+		at: 'crossorigin' append: 'anonymous'."	
 		
 ]

--- a/src/Bootstrap5-Examples/SBSBootstrapExample.class.st
+++ b/src/Bootstrap5-Examples/SBSBootstrapExample.class.st
@@ -26,8 +26,11 @@ SBSBootstrapExample >> renderContentOn: html [
 	html heading: self class exampleName; horizontalRule.
 	self renderExampleOn: html ].
 
-	html script 
-		url: 'https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js'
+				"<sm> line below moved to end SBSExamplesHome - also changed to 5.1.0 
+				but suggest a feature to automatically insert at end of each displayed page"
+
+	"html script 
+		url: 'https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js'"
 ]
 
 { #category : #rendering }
@@ -52,7 +55,10 @@ SBSBootstrapExample >> style [
 SBSBootstrapExample >> updateRoot: htmlRoot [
 
 	super updateRoot: htmlRoot.
+
+				"<sm> line below moved to end SBSExamplesHome - also changed to 5.1.0 
+				but suggest a feature to automatically insert at end of each displayed page"
 	 
-htmlRoot javascript 
-	url: 'https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js' 
+"htmlRoot javascript 
+	url: 'https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js' "
 ]

--- a/src/Bootstrap5-Examples/SBSCarouselExample.class.st
+++ b/src/Bootstrap5-Examples/SBSCarouselExample.class.st
@@ -18,6 +18,7 @@ SBSCarouselExample >> renderExampleOn: html [
 
 	html carousel 
 		id: 'example';
+		attributeAt: 'data-bs-ride' put: 'carousel';     	"<sm> changes - tag to be created for first time autoplay javascript not to be used"		
 		slide; with:[ 
 		html carouselInner: [
 			html carouselItem active with: [ html html: SBSCardExample imagePlaceHolderSVG ].
@@ -27,5 +28,5 @@ SBSCarouselExample >> renderExampleOn: html [
 		html carouselControlPreviousFor: 'example'.	
 		html carouselControlNextFor: 'example'. 	
 	].
-	html script: '$(".carousel").carousel()'
+	"html script: '$("".carousel"").carousel()'"  			"<sm> commented out as javascript not required"
 ]

--- a/src/Bootstrap5-Examples/SBSExamplesHome.class.st
+++ b/src/Bootstrap5-Examples/SBSExamplesHome.class.st
@@ -83,8 +83,15 @@ SBSExamplesHome >> renderContentOn: html [
 	self renderNavigationbarOn: html.
 	self isDisplayingIntro 
 			ifTrue: [ self renderIntroOn: html ]
-			ifFalse: [ browser renderOn: html ]
+			ifFalse: [ browser renderOn: html ].
 	 
+		"<sm> inserted as bs5 requires their javascript to be at end of the page before </body> tag for all UIs, also changed to 5.1.0 
+		but suggest a feature to automatically insert at end of each displayed page"
+			
+	html script  
+		url: 'https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/js/bootstrap.bundle.min.js';
+		attributeAt: 'integrity' put: 'sha384-U1DAWAznBHeqEIlVSCgzq+c9gqGAJn5c/t99JyeKa9xxaYpSvHU5awsuZVVFIhvj';
+		attributeAt: 'crossorigin' put: 'anonymous'.	
 ]
 
 { #category : #'rendering components' }


### PR DESCRIPTION
1. Bootstrap JS required before closing </body> tag and not in root - made changes in SBSCDNDeployment library to remove from root to check this out. Also thru seaside/config removed JQDevelopmentLibrary as not required and changed SBSDevelopmentLibrary to above SBSCDNDeploymentLibrary to check out

but maybe a feature is required to automatically include the BS Javascript at end of each page - like a mirror function to updateroot

2. Included BS5 JS 5.1.0 library in SBSExamplesHome and removed 2 references in SBSBootstrapExample - possibly more uniform, and in any case they were 5.0.2

3. Carousel fixed for autoanimate

4. Collapse fixed for collapse toggle working after expansion (it was not collapsing)

5. rest everything seems fine     