### PR TITLE
linkButton tag with SBSLinkButtonTag added

### DIFF
--- a/src/Bootstrap5-Core/SBSHtmlCanvas.class.st
+++ b/src/Bootstrap5-Core/SBSHtmlCanvas.class.st
@@ -1021,6 +1021,21 @@ SBSHtmlCanvas >> jumbotron: aBlock [
 		with: aBlock
 ]
 
+{ #category : #'as yet unclassified' }
+SBSHtmlCanvas >> linkButton [
+	"Defines a Bootstrap button."
+
+	^self brush: SBSLinkButtonTag new
+]
+
+{ #category : #'as yet unclassified' }
+SBSHtmlCanvas >> linkButton: aBlock [
+	"Provides a Bootstrap button that is a link."
+
+	 ^ self linkButton
+		with: aBlock
+]
+
 { #category : #listgroups }
 SBSHtmlCanvas >> listGroup [
 	"Provide a Bootstrap list group."

--- a/src/Bootstrap5-Core/SBSLinkButtonTag.class.st
+++ b/src/Bootstrap5-Core/SBSLinkButtonTag.class.st
@@ -1,0 +1,39 @@
+Class {
+	#name : #SBSLinkButtonTag,
+	#superclass : #SBSAnchorTag,
+	#traits : 'SBSTContextualStyled + SBSTSizeStyled',
+	#classTraits : 'SBSTContextualStyled classTrait + SBSTSizeStyled classTrait',
+	#instVars : [
+		'type'
+	],
+	#category : #'Bootstrap5-Core'
+}
+
+{ #category : #defaults }
+SBSLinkButtonTag >> defaultModifier [
+	"Subclasses may override to use a different modifier uses with the class style definitions"
+
+	^''
+]
+
+{ #category : #defaults }
+SBSLinkButtonTag >> defaultStyleClass [
+
+	^'btn'
+]
+
+{ #category : #'as yet unclassified' }
+SBSLinkButtonTag >> initialize [
+
+	super initialize.
+	type := 'button'.
+	self class: self defaultStyleClass.
+
+	self contextStyle: self defaultStyleClass.
+	self modifier: self defaultModifier.
+
+	self sizeStyle: self defaultStyleClass.	
+	
+	
+	self attributeAt: 'role' put: 'button' 
+]


### PR DESCRIPTION
linkButton is a button that can be placed within a form area and when clicked does **not** submit the form.  Other types of button seem to submit the form containing the button.

this button is useful where a button is needed for functionality while a form is in progress, e.g. to send OTP, retrieve and display a popup etc.

i couldnt find anything with this functionality in the seaside-bootstrap package though mentioned in getbootstrap but if something is there i can shift and discard this.

tests, examples and comments in class are not written but can be filled in if this is to be used