### PR TITLE
Add a baseline 'Core' option to seaside 3 dependency

### DIFF
--- a/src/BaselineOfBootstrap5/BaselineOfBootstrap5.class.st
+++ b/src/BaselineOfBootstrap5/BaselineOfBootstrap5.class.st
@@ -17,7 +17,7 @@ BaselineOfBootstrap5 >> baseline: spec [
 		self seaside: spec.
 
 		spec
-			package: 'Bootstrap5-Core' with: [ spec requires: #('Seaside3') ];
+			package: 'Bootstrap5-Core' with: [ spec requires: #('Seaside3-Core') ];
 		 	package: 'Bootstrap5-Core-Tests' with: [ spec requires: #('Bootstrap5-Core') ];
 			package: 'Bootstrap5-Examples' with: [ spec requires: #('Bootstrap5-Core') ].
 
@@ -25,7 +25,7 @@ BaselineOfBootstrap5 >> baseline: spec [
 			group: 'Core' with: #('Bootstrap5-Core');
 			group: 'Tests' with: #('Bootstrap5-Core-Tests');
 			group: 'Examples' with: #('Bootstrap5-Examples');
-			group: 'all' with: #('Tests' 'Examples');
+			group: 'all' with: #('Tests' 'Examples' 'Seaside3-default');
 			group: 'default' with: #('all').
 	]
 ]
@@ -34,9 +34,9 @@ BaselineOfBootstrap5 >> baseline: spec [
 BaselineOfBootstrap5 >> seaside: spec [
 
 	spec
-			baseline: 'Seaside3'
-        	with: [
-				spec
-					loads: #('Core');
-					repository: 'github://SeasideSt/Seaside:master/repository' ]
+		baseline: 'Seaside3'
+      with: [ spec repository: 'github://SeasideSt/Seaside:master/repository' ];
+	   project: 'Seaside3-core' copyFrom: 'Seaside3' with: [ spec loads: #('Core') ];
+		project: 'Seaside3-default' copyFrom: 'Seaside3' with: [ spec loads: #('default') ].
+			
 ]

--- a/src/BaselineOfBootstrap5/BaselineOfBootstrap5.class.st
+++ b/src/BaselineOfBootstrap5/BaselineOfBootstrap5.class.st
@@ -34,9 +34,7 @@ BaselineOfBootstrap5 >> baseline: spec [
 BaselineOfBootstrap5 >> seaside: spec [
 
 	spec
-		baseline: 'Seaside3'
-      with: [ spec repository: 'github://SeasideSt/Seaside:master/repository' ];
-	   project: 'Seaside3-Core' copyFrom: 'Seaside3' with: [ spec loads: #('Core') ];
-		project: 'Seaside3-default' copyFrom: 'Seaside3' with: [ spec loads: #('default') ].
-			
+		baseline: 'Seaside3' with: [ spec repository: 'github://SeasideSt/Seaside:master/repository' ];
+		project: 'Seaside3-Core' copyFrom: 'Seaside3' with: [ spec loads: #( 'Core' ) ];
+		project: 'Seaside3-default' copyFrom: 'Seaside3' with: [ spec loads: #( 'default' ) ]
 ]

--- a/src/BaselineOfBootstrap5/BaselineOfBootstrap5.class.st
+++ b/src/BaselineOfBootstrap5/BaselineOfBootstrap5.class.st
@@ -23,8 +23,8 @@ BaselineOfBootstrap5 >> baseline: spec [
 
 		spec
 			group: 'Core' with: #('Bootstrap5-Core');
-			group: 'Tests' with: #('Bootstrap5-Core-Tests');
-			group: 'Examples' with: #('Bootstrap5-Examples');
+			group: 'Tests' with: #('Bootstrap5-Core-Tests' 'Seaside3-default');
+			group: 'Examples' with: #('Bootstrap5-Examples' 'Seaside3-default');
 			group: 'all' with: #('Tests' 'Examples' 'Seaside3-default');
 			group: 'default' with: #('all').
 	]

--- a/src/BaselineOfBootstrap5/BaselineOfBootstrap5.class.st
+++ b/src/BaselineOfBootstrap5/BaselineOfBootstrap5.class.st
@@ -36,7 +36,7 @@ BaselineOfBootstrap5 >> seaside: spec [
 	spec
 		baseline: 'Seaside3'
       with: [ spec repository: 'github://SeasideSt/Seaside:master/repository' ];
-	   project: 'Seaside3-core' copyFrom: 'Seaside3' with: [ spec loads: #('Core') ];
+	   project: 'Seaside3-Core' copyFrom: 'Seaside3' with: [ spec loads: #('Core') ];
 		project: 'Seaside3-default' copyFrom: 'Seaside3' with: [ spec loads: #('default') ].
 			
 ]

--- a/src/BaselineOfBootstrap5/BaselineOfBootstrap5.class.st
+++ b/src/BaselineOfBootstrap5/BaselineOfBootstrap5.class.st
@@ -37,6 +37,6 @@ BaselineOfBootstrap5 >> seaside: spec [
 			baseline: 'Seaside3'
         	with: [
 				spec
-					loads: #('default');
+					loads: #('Core');
 					repository: 'github://SeasideSt/Seaside:master/repository' ]
 ]


### PR DESCRIPTION
When loading the Core baseline from this package, the Seaside 3 dependency loads all of its contents.
This PR updates the baseline so that Core only loads the Seaside3 Core baseline.

